### PR TITLE
build: proper runner name

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    runs-on: Temp-64-Core-Ubutnu-Runner
+    runs-on: anduro-runner
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Rename runner to `anduro-runner` because it is:
- Permanent
- Better named