### PR TITLE
Reduces verbosity of Geth logging

### DIFF
--- a/scripts/utils/geth.sh
+++ b/scripts/utils/geth.sh
@@ -66,7 +66,7 @@ function start_geth() {
         --ws.origins "*" \
         --port ${PORT} \
         --gcmode "archive" \
-        --verbosity 5 \
+        --verbosity 1
         --log.file $LOG_FILE \
         --syncmode full \
         --maxpeers 20 \
@@ -126,7 +126,7 @@ function start_testnet_geth() {
         --ws.addr "0.0.0.0" \
         --ws.port ${WS_PORT} \
         --ws.origins "*" \
-        --verbosity 2 \
+        --verbosity 1 \
         --log.file $LOG_FILE \
         --gpo.ignoreprice 1 \
         --metrics \


### PR DESCRIPTION
Decreases the verbosity level for both main Geth and testnet Geth configurations.

This reduces the amount of log output, making it easier to identify relevant information and debug issues.