### PR TITLE
An 126 Update Alys Docs for Alys setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,50 +179,12 @@ bitcoin-cli -regtest -rpcuser=rpcuser -rpcpassword=rpcpassword listtransactions 
 
 </details>
 
-## Full Node
-
-Running a full node is similar to running a federation node. The main difference is that full nodes do not require an Aura or Bitcoin key since they are not signing blocks or Bitcoin transactions.
-
-1. Start Bitcoin with the network you want to connect to via `bitcoind`.
-2. Start geth via `NUM=0 ./scripts/start_geth.sh` (assuming you run the full node on a different machine. If running on the same machine as the three nodes, use `NUM=3 ./scripts/start_geth.sh`)
-3. Start the full node assuming the full node runs on a seperate machine:
-
-```shell
-cargo run --bin app -- \
-  --chain etc/config/chain.json \
-  --geth-url http://localhost:8551/ \
-  --db-path etc/data/consensus/node_0/chain_db/ \
-  --rpc-port 3000 \
-  --wallet-path etc/data/consensus/node_0/wallet \
-  --bitcoin-rpc-url localhost:18332 \
-  --bitcoin-rpc-user rpcuser \
-  --bitcoin-rpc-pass rpcpassword \
-  --bitcoin-network testnet \
-  --remote-bootnode /ip4/BOOTNODE_IP/tcp/BOOTNODE_LIBP2P_PORT
-```
-
-- `BOOTNODE_IP`: To select a bootnode, get its public or private IP address.
-- `BOOTNODE_LIBP2P_PORT`: There are two ways to get the p2p port.
-  - You can find the listening port by running `lsof -Pn -i4` on the server running the bootnode.
-  - Set the P2P port explicitly: You can set a dedicated p2p port on the federation node/bootnode by adding the argument `--p2p-port 55444` to set this to port `55444`. Make sure to pick a free port.
 
 ## Development
 
 ### Alys Node (Consensus Layer)
 
-#### Build and Deploy
-
-```shell
-# cleanup, init and run geth
-./scripts/start_geth.sh
-
-# start bitcoin
-bitcoind -regtest -rpcuser=rpcuser -rpcpassword=rpcpassword -fallbackfee=0.002
-
-# dev (single node)
-cargo run --bin app -- --dev
-```
-
+First, follow the manual setup guide [here](./docs/guides/getting_started_manual_setup.md) to get your local environment setup.
 
 #### Unit tests
 
@@ -230,12 +192,6 @@ Tests are self-contained such that none of the services need to run.
 
 ```shell
 cargo test
-```
-
-#### Format
-
-```shell
-cargo fmt
 ```
 
 ### Smart Contracts

--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ On a high level, the repository consists of three parts:
 
 ## Prerequisites
 
-- Install Rust `1.75.0` or higher: https://www.rust-lang.org/tools/install
-- Install Geth `<=1.14.10`: https://geth.ethereum.org/docs/getting-started/installing-geth
-- Install Bitcoin Core `25.0` or higher so that you have access to the `bitcoind` and `bitcoin-cli` commands:
+- Install Rust `1.87.0` or higher: https://www.rust-lang.org/tools/install
+- Install Geth `1.14.10`: https://geth.ethereum.org/docs/getting-started/installing-geth
+- Install Bitcoin Core `28.0` or higher so that you have access to the `bitcoind` and `bitcoin-cli` commands:
   - MacOS: `brew install bitcoin`
   - Ubuntu: `sudo add-apt-repository ppa:bitcoin/bitcoin && sudo apt-get update && sudo apt-get install bitcoind`
   - Arch: `yay bitcoin-core`
   - Download a binary: https://bitcoin.org/en/download
 - Install clang
+- Install cmake `3.31.3`
 - Install pkg-config
 - Install libssl-dev
 - Install build-essential
@@ -35,9 +36,13 @@ On a high level, the repository consists of three parts:
 
 To help you get started with Alys, we provide two guides. The first guide demonstrates how to set up and run Alys using Docker Compose, which is the easiest and quickest way to get started. The second guide walks you through a manual setup process for more control and customization.
 * ### [Running Alys with Docker Compose](./docs/guides/getting_started_docker_setup.md)
-* ### [Running Alys - Manual setup](./docs/guides/getting_started_manual_setup.md)
+* ### [Running Alys - Manual setup](./docs/guides/getting_started_manual_setup.md) (for local development)
 
-## Alys Testnet4
+## Connecting to Alys Testnet4
+
+- Explorer: http://testnet.alyscan.io/
+- Faucet: https://faucet.anduro.io/
+- Chain ID: 212121
 
 Anduro operates a public testnet for Alys used for development & testing. Anyone wishing to interact with the Alys testnet, whether it be to query the chain, send transactions, or connect your own node to the
 network, can find connection info below.
@@ -58,6 +63,11 @@ Enode: enode://15d60f94195b361bf20acfd8b025b8f332b79f5752637e225e7c73aca7b17dd97
 ```shell
 IP: 209.160.175.125
 Enode: enode://53d6af0f549e4f9b4f768bc37145f7fd800fdbe1203652fd3d2ff7444663a4f5cfe8c06d5ed4b25fe3185920c28b2957a0307f1eed8af49566bba7e3f0c95b04@209.160.175.125:30303
+```
+
+To establish peering connections between the nodes, you can use the following command:
+```shell
+cast rpc admin_addTrustedPeer '["<enode_url_of_any_alys_node_listed_above>"]'
 ```
 
 ## Faucet
@@ -168,15 +178,6 @@ bitcoin-cli -regtest -rpcuser=rpcuser -rpcpassword=rpcpassword listtransactions 
 ```
 
 </details>
-
-## Connecting to an Alys Network
-
-### Testnet
-- RPC: http://209.160.175.123:8545
-- Explorer: http://testnet.alyscan.io/
-- Faucet: https://faucet.anduro.io/
-
-- Chain ID: 212121
 
 ## Full Node
 
@@ -388,6 +389,15 @@ When you start the Alys sidechain it will use a chain spec to configure it's own
 Each node should use the same genesis and chain spec, otherwise blocks will be rejected.
 
 Ensure that each federation member has set an EVM address to receive fees - this can be derived from the same secret key used to generate the public key in `"authorities"`. When fees are generated from EVM transactions they are sent directly to that account.
+
+## Important Links
+
+- [Alys Testnet4](https://testnet.alyscan.io/)
+- [Alys Faucet](https://faucet.anduro.io/)
+- [Alys Docs](https://github.com/AnduroProject/alys)
+- [Alys Github](https://github.com/anduroproject/alys)
+- [Alys Discord](https://discord.gg/Me3gjyZ2Nh)
+- [Alys Twitter](https://twitter.com/andurobtc)
 
 ## Resources
 

--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -195,10 +195,7 @@ impl App {
         let http_engine_json_rpc =
             new_http_engine_json_rpc(self.geth_url, JwtKey::from_slice(&self.jwt_secret).unwrap());
         let public_execution_json_rpc = new_http_public_execution_json_rpc(self.geth_execution_url);
-        let engine = Engine::new(
-            http_engine_json_rpc,
-            public_execution_json_rpc,
-        );
+        let engine = Engine::new(http_engine_json_rpc, public_execution_json_rpc);
 
         let network = crate::network::spawn_network_handler(
             self.p2p_listen_addr,

--- a/app/src/block_candidate/candidate_state.rs
+++ b/app/src/block_candidate/candidate_state.rs
@@ -1,9 +1,9 @@
-use lighthouse_wrapper::bls::PublicKey;
-use lighthouse_wrapper::store::MainnetEthSpec;
 use crate::block::SignedConsensusBlock;
 use crate::error::Error;
 use crate::network::ApproveBlock;
 use crate::signatures::CheckedIndividualApproval;
+use lighthouse_wrapper::bls::PublicKey;
+use lighthouse_wrapper::store::MainnetEthSpec;
 
 /// CandidateState enum represents the state of a block candidate.
 #[allow(clippy::large_enum_variant)]

--- a/app/src/block_candidate/mod.rs
+++ b/app/src/block_candidate/mod.rs
@@ -1,13 +1,11 @@
 pub mod block_candidate_cache;
 mod candidate_state;
 
-use async_trait::async_trait;
 use crate::block::SignedConsensusBlock;
 use crate::error::Error;
 use crate::network::ApproveBlock;
-use block_candidate_cache::{
-    BlockCandidateCache, BlockCandidateCacheTrait,
-};
+use async_trait::async_trait;
+use block_candidate_cache::{BlockCandidateCache, BlockCandidateCacheTrait};
 use candidate_state::CandidateState;
 use lighthouse_wrapper::bls::PublicKey;
 use lighthouse_wrapper::execution_layer::Hash256;
@@ -28,7 +26,7 @@ impl BlockCandidates {
             cache: RwLock::new(BlockCandidateCache::new()),
         }
     }
-    
+
     /// Clears all candidates from the cache.
     #[allow(dead_code)]
     pub async fn clear(&self) {
@@ -40,7 +38,7 @@ impl BlockCandidates {
     pub async fn len(&self) -> usize {
         self.cache.read().await.len()
     }
-    
+
     /// Returns true if the cache is empty.
     #[allow(dead_code)]
     pub async fn is_empty(&self) -> bool {

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1930,11 +1930,7 @@ impl<DB: ItemStore<MainnetEthSpec>> ChainManager<ConsensusBlock<MainnetEthSpec>>
     fn get_last_finalized_block(&self) -> ConsensusBlock<MainnetEthSpec> {
         trace!("Getting last finalized block");
         match self.storage.get_latest_pow_block() {
-            Ok(Some(x)) => {
-                let last_block = self.storage.get_block(&x.hash).unwrap().unwrap().message;
-
-                last_block
-            }
+            Ok(Some(x)) => self.storage.get_block(&x.hash).unwrap().unwrap().message,
             _ => unreachable!("Should always have AuxPow"),
         }
     }

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -5,6 +5,7 @@ use crate::auxpow_miner::{
     get_next_work_required, BitcoinConsensusParams, BlockIndex, ChainManager,
 };
 use crate::block::{AuxPowHeader, ConsensusBlock, ConvertBlockHash};
+use crate::block_candidate::block_candidate_cache::BlockCandidateCacheTrait;
 use crate::block_candidate::BlockCandidates;
 use crate::block_hash_cache::{BlockHashCache, BlockHashCacheInit};
 use crate::engine::{ConsensusAmount, Engine};
@@ -45,7 +46,6 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::RwLock;
 use tracing::*;
-use crate::block_candidate::block_candidate_cache::BlockCandidateCacheTrait;
 
 pub(crate) type BitcoinWallet = UtxoManager<Tree>;
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -3,6 +3,7 @@ mod aura;
 mod auxpow;
 mod auxpow_miner;
 mod block;
+mod block_candidate;
 mod block_hash_cache;
 mod chain;
 mod engine;
@@ -13,7 +14,6 @@ mod rpc;
 mod signatures;
 mod spec;
 mod store;
-mod block_candidate;
 
 // for main.rs
 pub use app::run;

--- a/app/src/network/mod.rs
+++ b/app/src/network/mod.rs
@@ -432,6 +432,7 @@ fn create_swarm() -> Result<Swarm<MyBehaviour>, Error> {
             };
 
             // Set a custom gossipsub configuration
+            #[allow(clippy::io_other_error)]
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .heartbeat_interval(Duration::from_secs(10)) // This is set to aid debugging by not cluttering the log space
                 .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message signing)

--- a/docs/guides/getting_started_docker_setup.md
+++ b/docs/guides/getting_started_docker_setup.md
@@ -68,7 +68,7 @@ $ docker compose -f etc/docker-compose.j2.yml logs -f
 
 #### Step 1. 
 
-Alys full nodes do **NOT** sign blocks or Bitcoin transactions. Thus, you do not need to generate secret keys for signing. You only need to update your docker-compose file with a valid `BOOTNODE_ARG`:
+Alys full nodes do **NOT** sign blocks or Bitcoin transactions. Thus, you do **NOT** need to generate secret keys for signing (Aura or Bitcoin keys). You only need to update your docker-compose file with a valid `BOOTNODE_ARG`:
 
 `BOOTNODE_ARG=/ip4/209.160.175.125/tcp/55444`
 

--- a/docs/guides/getting_started_docker_setup.md
+++ b/docs/guides/getting_started_docker_setup.md
@@ -85,7 +85,3 @@ Check the logs to see if everything is running smoothly.
 ```sh
 $ docker compose -f etc/docker-compose.j2.yml logs -f
 ```
-
-## *Option* #3: (Local Development) Run entire Alys stack
-
-*coming soon...*

--- a/docs/guides/getting_started_manual_setup.md
+++ b/docs/guides/getting_started_manual_setup.md
@@ -2,29 +2,36 @@
 
 The instructions below demonstrate how to run an Alys sidechain consisting of a single local node, and a single-member federation.
 
-### Geth and Bitcoin
+> This is intended for local development.
 
-We will start a single geth node and a Bitcoin regtest node.
-
-```shell
-# cleanup, init and run geth
-./scripts/start_geth.sh
-```
+### Bitcoin
 
 ```shell
 # in a new terminal start bitcoin
 bitcoind -regtest -server -rest -rpcport=18443 -rpcuser=rpcuser -rpcpassword=rpcpassword -fallbackfee=0.002 -rpcallowip=127.0.0.1 -debug=rpc
 ```
 
+> IMPORTANT: Make sure your are running version `28.0.0` or higher of Bitcoin Core.
+
+### Geth
+
+In a new terminal, start Geth. Make sure you are running version `1.14.0` of Geth.
+
+```shell
+./scripts/start_geth.sh
+```
+
 ### Alys node
 
 Next, we start a single Alys node with the federation having exactly one member.
+
+Make sure you are using Rust version `1.87.0` or higher.
 
 ```shell
 # dev (single node)
 
 # From the Alys root directory
-cargo run --bin app -- --dev
+cargo run --bin app -- --dev --jwt-secret <your_jwt_secret>
 ```
 
 After running the above commands, you will have a local Alys node running with a single-member federation. You can interact with the node by making RPC calls to it. The default RPC port is `3000`.

--- a/etc/docker-compose.full-node.yml
+++ b/etc/docker-compose.full-node.yml
@@ -84,9 +84,6 @@ services:
   consensus:
     container_name: consensus
     restart: unless-stopped
-#    build:
-#      context: ../
-#      dockerfile: Dockerfile
     image: ghcr.io/anduroproject/alys:master
     ports:
       - 3000:3000
@@ -121,16 +118,6 @@ services:
       - "55444"
       - --jwt-secret
       - /opt/alys/execution/config/jwtsecret.hex
-#      - --bitcoin-rpc-url
-#      - http://{{ BTC_NODE_IP }}:18332
-#      - --bitcoin-rpc-user
-#      - rpcuser
-#      - --bitcoin-rpc-pass
-#      - rpcpassword
-#      - --bitcoin-network
-#      - testnet
-#      - --p2p-listen-address
-#      - {{hostvars[inventory_hostname].ansible_host}}
     depends_on:
       - execution
 

--- a/etc/docker-compose.j2.yml
+++ b/etc/docker-compose.j2.yml
@@ -84,9 +84,6 @@ services:
   consensus:
     container_name: consensus
     restart: unless-stopped
-    #    build:
-    #      context: ../
-    #      dockerfile: Dockerfile
     image: ghcr.io/anduroproject/alys:master
     ports:
       - 3000:3000
@@ -133,8 +130,6 @@ services:
       - "55444"
       - --jwt-secret
       - /opt/alys/execution/config/jwtsecret.hex
-    #      - --p2p-listen-address
-    #      - {{hostvars[inventory_hostname].ansible_host}}
     depends_on:
       - execution
 

--- a/etc/docker-compose.local.yml
+++ b/etc/docker-compose.local.yml
@@ -82,9 +82,6 @@ services:
   consensus:
     container_name: consensus
     restart: unless-stopped
-#    build:
-#      context: ../
-#      dockerfile: Dockerfile
     image: ghcr.io/anduroproject/alys:master
 
     volumes:


### PR DESCRIPTION
### Documentation Updates:
* Updated dependency versions in `README.md`, including Rust (`1.87.0` or higher), Geth (`1.14.10`), and Bitcoin Core (`28.0` or higher). Added `cmake` as a prerequisite.
* Added new sections to `README.md` for connecting to Alys Testnet4, including links to the Explorer and Faucet, and instructions for peering connections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R45) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68-R72)
* Simplified and clarified the manual setup guide in `docs/guides/getting_started_manual_setup.md`, including updated Bitcoin and Geth instructions and a note on required versions.

### Removal of Deprecated Content:
* Removed outdated sections in `README.md` related to running a full node and development setup, consolidating instructions into the manual setup guide. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L172-R187) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L234-L239)

### Docker Compose Cleanup:
* Removed commented-out and unused configurations from `etc/docker-compose.full-node.yml`, `etc/docker-compose.j2.yml`, and `etc/docker-compose.local.yml` to reduce clutter and improve readability. [[1]](diffhunk://#diff-163fbea38481851625b80d714bcab45af46f0b341021562487b40d32f8e1ae65L87-L89) [[2]](diffhunk://#diff-163fbea38481851625b80d714bcab45af46f0b341021562487b40d32f8e1ae65L124-L133) [[3]](diffhunk://#diff-19b779a8f541fd6b769dcb7324fda64f03e208451860dea3fcdc4377db076c88L87-L89) [[4]](diffhunk://#diff-19b779a8f541fd6b769dcb7324fda64f03e208451860dea3fcdc4377db076c88L136-L137) [[5]](diffhunk://#diff-fd711073cf63315b91cbd9abe1ecae7e0ea5a9e37265eb7cf834d91b70f11254L85-L87)

### Additional Links:
* Added an "Important Links" section to `README.md` with references to the Alys Testnet, Faucet, documentation, GitHub repository, Discord, and Twitter.