### PR TITLE
AN-123: Rolls back head on block import error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,4 +91,4 @@ jobs:
       - name: Build & Test
         run: |
           cargo build --release
-          cargo test --release --no-fail-fast --verbose -- --nocapture --test-threads=1
+          cargo test --release --no-fail-fast --verbose -- --nocapture

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1773,7 +1773,9 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                         }
                         Err(err) => {
                             error!("Unexpected block import error: {:?}", err);
-                            self.rollback_head(head - 1).await.unwrap();
+                            if let Err(rollback_err) = self.rollback_head(head - 1).await {
+                                error!("Failed to rollback head: {:?}", rollback_err);
+                            }
 
                             return;
                         }

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1773,6 +1773,8 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                         }
                         Err(err) => {
                             error!("Unexpected block import error: {:?}", err);
+                            self.rollback_head(head - 1).await.unwrap();
+
                             return;
                         }
                     }


### PR DESCRIPTION
Rolls back the chain head by one block when an unexpected block import error occurs. This ensures that the chain remains in a consistent state and prevents potential corruption.