### PR TITLE
Alys Node P2P Reconnection capability

### DIFF
--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1882,7 +1882,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                             );
                             chain.queued_pegins.write().await.insert(pegin.txid, pegin);
                             CHAIN_BTC_BLOCK_MONITOR_TOTALS
-                                .with_label_values(&["queued_pegins"])
+                                .with_label_values(&["queued_pegins", "synced"])
                                 .inc();
                         } else {
                             debug!(
@@ -1890,7 +1890,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                                 pegin.amount, pegin.evm_account, pegin.txid
                             );
                             CHAIN_BTC_BLOCK_MONITOR_TOTALS
-                                .with_label_values(&["ignored_pegins"])
+                                .with_label_values(&["ignored_pegins", "not_synced"])
                                 .inc();
 
                             break;

--- a/app/src/network/mod.rs
+++ b/app/src/network/mod.rs
@@ -284,7 +284,8 @@ impl NetworkBackend {
         > = HashMap::new();
         let mut next_id = 0;
 
-        let mut reconnect_timer = tokio::time::interval(Duration::from_secs(RECONNECT_INTERVAL_SECS));
+        let mut reconnect_timer =
+            tokio::time::interval(Duration::from_secs(RECONNECT_INTERVAL_SECS));
 
         loop {
             select! {


### PR DESCRIPTION
## Summary

This PR introduces peer reconnection mechanism to handle unexpected disconnections.

## Key Features

- **Address Tracking**  
  Stores peer addresses upon connection for future reconnection attempts.
  Added peer_addresses and reconnect_info fields in NetworkBackend to manage peer reconnection data. [1] [2]

- **Exponential Backoff**  
  Applies `2^attempt_count` seconds delay between reconnection attempts, capped at ~1hr.

- **Smart Reconnection Logic**  
  Only reconnects after unexpected disconnections; avoids retrying on expected terminations (e.g., timeouts).

- **Attempt Limiting**  
  Stops reconnection after 10 failed attempts to prevent infinite retry loops.

- **Periodic Reconnection Checks**  
  A 5-second interval task scans for disconnected peers needing reconnection.

- **Improved logging for dialing and reconnections**: Added detailed log messages for dialing peers and initiating reconnection attempts, including reasons for giving up reconnections. [[1]](diffhunk://#diff-97da2183009e3bfad8eacbbcee07aa3753a72c53d9d6af769f134a32bec9c98bL249-R293) [[2]](diffhunk://#diff-97da2183009e3bfad8eacbbcee07aa3753a72c53d9d6af769f134a32bec9c98bL349-R464)

- **Stored peer addresses**: Added `peer_addresses` and `reconnect_info` fields in `NetworkBackend` to manage peer reconnection data. [[1]](diffhunk://#diff-97da2183009e3bfad8eacbbcee07aa3753a72c53d9d6af769f134a32bec9c98bR217-R258) [[2]](diffhunk://#diff-97da2183009e3bfad8eacbbcee07aa3753a72c53d9d6af769f134a32bec9c98bR502-R503)

## Testing

This was tested on Alys testnet using Alys2 & Alys3. I used Alys2 to run consensus client with reconnection logic and peered with Alys3. I manually brought down Alys3 to force a disconnection event. As can be seen in the logs (below) on Alys2, the simulated peer disconnection took effect and Alys2 began trying to **reconnect**.

<img width="1440" alt="Screenshot 2025-06-26 at 11 15 15 AM" src="https://github.com/user-attachments/assets/3799eb59-4e22-4c8e-bde7-7bcb8d92d310" />


After 3 attempts (to test exponential backoff) you can see the peer connection was re-established (below)

<img width="1136" alt="Screenshot 2025-06-26 at 11 16 26 AM" src="https://github.com/user-attachments/assets/424c1502-2981-4d2c-a5a1-981a3e5c09e0" />


Closes AN-124-alys-node-p-2-p-reconnection-capability