### PR TITLE
Add `setbtcscanheight` rpc command

### DIFF
--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1935,6 +1935,10 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
         }
     }
 
+    pub fn set_bitcoin_scan_start_height(&self, height: u32) -> Result<(), Error> {
+        self.storage.set_bitcoin_scan_start_height(height)
+    }
+
     pub fn get_block(
         self: &Arc<Self>,
         block_hash: &Hash256,

--- a/app/src/rpc.rs
+++ b/app/src/rpc.rs
@@ -19,6 +19,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::error;
+use tracing::info;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct JsonRpcRequestV1<'a> {
@@ -365,6 +366,31 @@ async fn http_req_json_rpc<BI: BlockIndex, CM: ChainManager<BI>, DB: ItemStore<M
                     }
                     .into(),
                 )
+            }
+        },
+        "setbtcscanheight" => match params.get().parse::<u32>() {
+            Ok(target_height) => {
+                // block_response_helper(id, chain.get_block_by_height(target_height))
+                info!(
+                    "clearbtcscanheight: clearing btc scan height to {}",
+                    target_height
+                );
+                chain.set_bitcoin_scan_start_height(target_height).unwrap();
+                Response::builder().status(hyper::StatusCode::OK).body(
+                    JsonRpcResponseV1 {
+                        result: Some(json!(())),
+                        error: None,
+                        id,
+                    }
+                    .into(),
+                )
+            }
+            Err(e) => {
+                return Ok(new_json_rpc_error!(
+                    id,
+                    hyper::StatusCode::BAD_REQUEST,
+                    JsonRpcErrorV1::debug_error(e.to_string())
+                )?)
             }
         },
         _ => {


### PR DESCRIPTION
Alys1 is experiencing the same issue as Alys3 where it's streaming BTC blocks in the future for peg-ins. This ultimately has the Alys node waiting for that future BTC block before it actively starts handling peg-in Txs.

Refer to AN-102 Pegin txs not confirming #84 for a more in depth explanation of the underlying issue.

I believe that I forgot to manually reset the btc streaming start height for Alys1 which was done for Alys3.