### PR TITLE
An 166 alys nodes failed to sync 1064192

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "tokio-io-timeout",
  "tokio-util 0.6.10",
  "tracing",
+ "tracing-futures",
  "tracing-subscriber",
  "tree_hash",
  "tree_hash_derive",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -30,6 +30,7 @@ eyre = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-futures = "0.2"
 strum = { version = "0.26", features = ["derive"] }
 thiserror = { workspace = true }
 slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1284,7 +1284,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
             .ok_or(Error::MissingBlock)?;
 
         info!(
-            "Last finalized {} (height {}) in block {}",
+            "Last finalized range_end_hash={} range_end_height={} in block {}",
             last_finalized.hash, last_finalized.height, last_pow,
         );
         let range_start_block =

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1007,12 +1007,13 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
         let last_pow_block = self
             .storage
             .get_block(&last_pow)?
-            .ok_or(Error::MissingParent)?;
+            .ok_or(Error::MissingBlock)?;
+
         info!("Last pow block {}", last_pow_block.canonical_root());
 
         let last_finalized = self
             .get_latest_finalized_block_ref()?
-            .ok_or(Error::MissingParent)?;
+            .ok_or(Error::MissingBlock)?;
 
         info!(
             "Last finalized {} (height {}) in block {}",

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -991,14 +991,14 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
 
         if self.is_validator {
             self.check_withdrawals(&unverified_block)
-                .instrument(tracing::debug_span!("check_withdrawals", 
+                .instrument(tracing::debug_span!("check_withdrawals",
                     block_height = unverified_block.message.execution_payload.block_number,
                     block_hash = %unverified_block.canonical_root()
                 ))
                 .await?;
 
             self.check_pegout_proposal(&unverified_block, prev_payload_hash)
-                .instrument(tracing::debug_span!("check_pegout_proposal", 
+                .instrument(tracing::debug_span!("check_pegout_proposal",
                     block_height = unverified_block.message.execution_payload.block_number,
                     block_hash = %unverified_block.canonical_root(),
                     prev_payload_hash = %prev_payload_hash

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -666,7 +666,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
 
         // Find the preceding finalized block
         let preceding_finalized = self.get_preceding_finalized_block(&target_block)?;
-        
+
         let rollback_block = if let Some(finalized) = preceding_finalized {
             // Use the preceding finalized block if found
             finalized

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -40,7 +40,7 @@ use lighthouse_wrapper::store::ItemStore;
 use lighthouse_wrapper::store::KeyValueStoreOp;
 use lighthouse_wrapper::types::{ExecutionBlockHash, Hash256, MainnetEthSpec};
 use std::collections::{BTreeMap, HashSet};
-use std::ops::{Add, DerefMut, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, DerefMut, Div, Mul, Sub};
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 use svix_ksuid::*;
@@ -1465,7 +1465,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                 // nothing to do
             }
         } else {
-            debug!("Block {hash} not found in cache");
+            debug!("Block {hash:?} not found in cache");
             return Err(Error::CandidateCacheError);
         }
 
@@ -1850,7 +1850,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                             .inc();
 
                         let number = x.message.execution_payload.block_number;
-	                    let received_block_hash = x.canonical_root();
+                        let received_block_hash = x.canonical_root();
 
                         info!("Received payload at height {number} {received_block_hash:?}");
                         let head_hash = self.head.read().await.as_ref().unwrap().hash;
@@ -2123,17 +2123,25 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                                 trace!("Successfully processed block at height {}", block_height);
                             }
                             Err(err) => {
-                                blocks_failed += 1;
-                                error!("Unexpected block import error at height {}: {:?}", block_height, err);
-
-                                async {
-                                    if let Err(rollback_err) = self.rollback_head(head - 1).await {
-                                        error!("Failed to rollback head: {:?}", rollback_err);
-                                    }
-                                }
-                                .instrument(tracing::debug_span!("rollback_on_sync_error", failed_height = block_height))
-                                .await;
-
+	                            let logging_closure = |blocks_failed_ref: &mut i32| {
+									blocks_failed_ref.add_assign(1);
+									error!("Unexpected block import error at height {}: {:?}", block_height, err);
+	                            };
+	                            match err {
+									Error::CandidateCacheError => {
+										logging_closure(&mut blocks_failed)
+									}
+		                            _ => {
+			                            async {
+										logging_closure(&mut blocks_failed);
+				                            if let Err(rollback_err) = self.rollback_head(head - 1).await {
+					                            error!("Failed to rollback head: {:?}", rollback_err);
+				                            }
+			                            }
+				                            .instrument(tracing::debug_span!("rollback_on_sync_error", failed_height = block_height))
+				                            .await;
+		                            }
+	                            }
                                 return;
                             }
                         }

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -662,7 +662,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
         let target_block = self
             .storage
             .get_block_by_height(target_height)?
-            .ok_or(Error::MissingParent)?;
+            .ok_or(Error::MissingBlock)?;
 
         // Find the preceding finalized block
         let preceding_finalized = self.get_preceding_finalized_block(&target_block)?;

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1982,14 +1982,14 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                         .unwrap_or_default();
                     let start_height = head + 1;
                     let block_count = 1024;
-                    
+
                     info!("Starting sync from height {} (requesting {} blocks from height {})", 
                           head, block_count, start_height);
-                    
+
                     CHAIN_SYNCING_OPERATION_TOTALS
                         .with_label_values(&[head.to_string().as_str(), "called"])
                         .inc();
-                        
+
                     (head, start_height, block_count)
                 }
                 .instrument(tracing::debug_span!("prepare_sync_request"))
@@ -2025,10 +2025,9 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                     RPCResponse::BlocksByRange(block) => {
                         blocks_processed += 1;
                         let block_height = block.message.execution_payload.block_number;
-                        
+
                         trace!("Processing sync block at height {}", block_height);
-                        
-                        #[warn(unused_assignments)]
+
                         match self.process_block((*block).clone()).await {
                             Err(Error::ProcessGenesis) | Ok(_) => {
                                 last_processed_height = block_height;
@@ -2037,7 +2036,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                             Err(err) => {
                                 blocks_failed += 1;
                                 error!("Unexpected block import error at height {}: {:?}", block_height, err);
-                                
+
                                 async {
                                     if let Err(rollback_err) = self.rollback_head(head - 1).await {
                                         error!("Failed to rollback head: {:?}", rollback_err);

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1850,10 +1850,9 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                             .inc();
 
                         let number = x.message.execution_payload.block_number;
-                        let payload_hash = x.message.execution_payload.block_hash;
-                        let payload_prev_hash = x.message.execution_payload.parent_hash;
+	                    let received_block_hash = x.canonical_root();
 
-                        info!("Received payload at height {number} {payload_prev_hash} -> {payload_hash}");
+                        info!("Received payload at height {number} {received_block_hash:?}");
                         let head_hash = self.head.read().await.as_ref().unwrap().hash;
                         let head_height = self.head.read().await.as_ref().unwrap().height;
                         debug!("Local head: {:#?}, height: {}", head_hash, head_height);

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1174,17 +1174,17 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
             header.range_start, header.range_end,
         );
 
-        let last_pow_block = self.storage.get_latest_pow_block()?.unwrap();
-        let last_pow = last_pow_block.hash;
+        let last_pow_block_ref = self.storage.get_latest_pow_block()?.unwrap();
+        let last_pow = last_pow_block_ref.hash;
 
-        info!("Last pow block: {}", last_pow);
+        info!("Last pow block: {} ({})", last_pow, last_pow_block_ref.height);
 
         let last_pow_block = self
             .storage
             .get_block(&last_pow)?
             .ok_or(Error::MissingBlock)?;
 
-        info!("Last pow block {}", last_pow_block.canonical_root());
+        info!("Last pow block {} canonical root", last_pow_block.canonical_root());
 
         let last_finalized = self
             .get_latest_finalized_block_ref()?

--- a/crates/federation/src/bitcoin_stream.rs
+++ b/crates/federation/src/bitcoin_stream.rs
@@ -123,10 +123,10 @@ impl BitcoinCore {
             match self.rpc.get_block_hash(height.into()) {
                 Ok(hash) => {
                     let info = self.rpc.get_block_info(&hash)?;
-                    info!(
-                        "wait_for_block: block {} exists with hash {} and confirmations {}",
-                        height, hash, info.confirmations
-                    );
+                    // info!(
+                    //     "wait_for_block: block {} exists with hash {} and confirmations {}",
+                    //     height, hash, info.confirmations
+                    // );
                     if info.confirmations >= num_confirmations as i32 {
                         return Ok(self.rpc.get_block(&hash)?);
                     } else {


### PR DESCRIPTION
# Add preceding finalized block lookup and improve rollback safety

This PR adds a new method `get_preceding_finalized_block` that finds the most recent finalized block preceding a given block, and updates the `rollback_head` method to use this for safer rollbacks.

## Changes

### New Method: `get_preceding_finalized_block`

- **Purpose**: Finds the preceding finalized block for any given block
- **Logic**: 
  - If the input block is finalized (has `auxpow_header`), finds the block that was finalized by the previous PoW block
  - Otherwise, traverses backwards through the chain until it finds a finalized block
  - Handles edge cases like genesis blocks and missing blocks
- **Returns**: `Option<SignedConsensusBlock<MainnetEthSpec>>` - the preceding finalized block if found, `None` if no preceding finalized block exists

### Updated Method: `rollback_head`

- **Before**: Rolled back to an arbitrary target height
- **After**: Finds the preceding finalized block and rolls back to that instead
- **Safety**: Ensures rollbacks always end at a finalized block, which is safer than rolling back to an arbitrary height
- **Fallback**: If no preceding finalized block is found, falls back to the original target block

### Enhancements to Validation and Error Handling:

* **Validation of block range in `get_hashes`**: Added checks to ensure that the `from` block has a smaller execution block number than the `to` block. If the range is invalid, the method returns early with the `from` block hash.
* **Error handling improvements**: Updated error messages for missing blocks in various parts of the code to use `Error::MissingBlock` instead of `Error::MissingParent`, providing more accurate error descriptions.

## Benefits

1. **Improved Safety**: Rollbacks now target finalized blocks instead of arbitrary heights
2. **Better Chain Integrity**: Prevents rolling back to potentially unstable non-finalized states
3. **Consistent Behavior**: All rollbacks now follow the same safety-first approach
4. **Maintainability**: Centralized logic for finding preceding finalized blocks

## Testing

The changes maintain backward compatibility and include proper error handling for edge cases:
- Genesis blocks (height 0)
- Missing blocks in the chain
- Blocks without parents
- Chains with no finalized blocks