### PR TITLE
Distribute RPC requests across peers

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -3,7 +3,7 @@ name: Solidity
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,14 +8,14 @@ name: Docker
 on:
   push:
     branches: 
-      - master
+      - main
       - development
       - 'feature/**'
       - 'AN-*'
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ "master", "development" ]
+    branches: [ "main", "development" ]
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
This commit introduces a random selection mechanism for peers in the Chain implementation, improving the robustness of peer discovery. The changes include:

- Replaced the deterministic selection of the first peer with a random choice from the available peers.
- Utilized the `rand` crate to facilitate random selection, enhancing the distribution of peer connections.

This update aims to optimize network interactions and reduce potential biases in peer selection during synchronization processes.