### PR TITLE
Fixes integer underflow panic during sync rollback

### DIFF
--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -2287,13 +2287,10 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                                         _ => {
                                             async {
                                                 logging_closure(&mut blocks_failed);
-                                                if let Err(rollback_err) =
-                                                    self.rollback_head(head.saturating_sub(1)).await
-                                                {
-                                                    error!(
-                                                        "Failed to rollback head: {:?}",
-                                                        rollback_err
-                                                    );
+                                                if head == 0 {
+                                                    error!("Cannot rollback head: head is already at 0");
+                                                } else if let Err(rollback_err) = self.rollback_head(head.saturating_sub(1)).await {
+                                                    error!("Failed to rollback head: {:?}", rollback_err);
                                                 }
                                             }
                                             .instrument(tracing::debug_span!(

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -519,7 +519,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
 
         if rollback_head {
             warn!("No payload head found");
-            self.rollback_head(prev_height - 1).await?;
+            self.rollback_head(prev_height.saturating_sub(1)).await?;
             return Ok(());
         }
 
@@ -2279,7 +2279,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
                                             async {
                                                 logging_closure(&mut blocks_failed);
                                                 if let Err(rollback_err) =
-                                                    self.rollback_head(head - 1).await
+                                                    self.rollback_head(head.saturating_sub(1)).await
                                                 {
                                                     error!(
                                                         "Failed to rollback head: {:?}",


### PR DESCRIPTION
Replace `head - 1` with `head.saturating_sub(1)` in sync error handling to prevent panic when attempting to rollback from height 0.

Fixes integer underflow that occurs when:
- Chain is empty (head = 0)
- Sync encounters processing errors
- Error handler attempts rollback to height -1

This prevents node crashes during initial sync with empty database.

Resolves: [AN-263]