### PR TITLE
Add support for multiple peer addresses in remote bootnode argument

### DIFF
--- a/app/src/network/mod.rs
+++ b/app/src/network/mod.rs
@@ -38,6 +38,19 @@ pub type EnrSyncCommitteeBitfield<T> = BitVector<<T as EthSpec>::SyncCommitteeSu
 const RECONNECT_INTERVAL_SECS: u64 = 5;
 const RECONNECT_MAX_ATTEMPTS: u32 = 12;
 
+/// Supported multiaddress protocols that can start a new multiaddress
+const SUPPORTED_MULTIADDR_PROTOCOLS: &[&str] = &[
+    "ip4",
+    "ip6", 
+    "dns",
+    "dns4",
+    "dns6",
+    "unix",
+    "p2p",
+    "p2p-webrtc-star",
+    "p2p-websocket-star",
+];
+
 #[derive(NetworkBehaviour)]
 struct MyBehaviour {
     gossipsub: gossipsub::Behaviour,
@@ -533,18 +546,7 @@ fn parse_multiple_multiaddrs(input: &str) -> Result<Vec<Multiaddr>, Error> {
                         if let Some(protocol_end) = input[protocol_start..].find('/') {
                             let protocol = &input[protocol_start..protocol_start + protocol_end];
                             // Check if this looks like a new multiaddress protocol
-                            if [
-                                "ip4",
-                                "ip6",
-                                "dns",
-                                "dns4",
-                                "dns6",
-                                "unix",
-                                "p2p",
-                                "p2p-webrtc-star",
-                                "p2p-websocket-star",
-                            ]
-                            .contains(&protocol)
+                            if SUPPORTED_MULTIADDR_PROTOCOLS.contains(&protocol)
                             {
                                 // Verify this is actually a new multiaddress by trying to parse it
                                 let potential_addr = &input[protocol_start - 1..];

--- a/app/src/network/mod.rs
+++ b/app/src/network/mod.rs
@@ -41,7 +41,7 @@ const RECONNECT_MAX_ATTEMPTS: u32 = 12;
 /// Supported multiaddress protocols that can start a new multiaddress
 const SUPPORTED_MULTIADDR_PROTOCOLS: &[&str] = &[
     "ip4",
-    "ip6", 
+    "ip6",
     "dns",
     "dns4",
     "dns6",
@@ -546,8 +546,7 @@ fn parse_multiple_multiaddrs(input: &str) -> Result<Vec<Multiaddr>, Error> {
                         if let Some(protocol_end) = input[protocol_start..].find('/') {
                             let protocol = &input[protocol_start..protocol_start + protocol_end];
                             // Check if this looks like a new multiaddress protocol
-                            if SUPPORTED_MULTIADDR_PROTOCOLS.contains(&protocol)
-                            {
+                            if SUPPORTED_MULTIADDR_PROTOCOLS.contains(&protocol) {
                                 // Verify this is actually a new multiaddress by trying to parse it
                                 let potential_addr = &input[protocol_start - 1..];
                                 if Multiaddr::from_str(potential_addr).is_ok() {


### PR DESCRIPTION
This pull request introduces a new utility function for parsing multiple multiaddresses from a string and updates the network handler to support dialing multiple bootnodes. The changes improve flexibility in handling multiaddress formats and enhance error handling for dialing operations.

### Parsing multiple multiaddresses:

* Added the `parse_multiple_multiaddrs` function in `app/src/network/mod.rs` to parse multiaddresses from strings in various formats: comma-separated, space-separated, or concatenated. It includes logic to identify and split concatenated multiaddresses at protocol boundaries.
* Added comprehensive unit tests for the `parse_multiple_multiaddrs` function to ensure correctness across different input formats, including valid, invalid, and empty inputs.

### Enhancements to network handler:

* Updated the `spawn_network_handler` function in `app/src/network/mod.rs` to use the new `parse_multiple_multiaddrs` function for parsing the `remote_bootnode` parameter. This allows dialing multiple bootnodes instead of a single one.
* Improved error handling in `spawn_network_handler` by logging warnings for individual bootnode dialing failures, ensuring the process continues for other addresses.