### PR TITLE
Monkey patch failed block validation at 70132

### DIFF
--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1128,6 +1128,11 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
         unverified_block: &SignedConsensusBlock<MainnetEthSpec>,
         prev_payload_hash: ExecutionBlockHash,
     ) -> Result<(), Error> {
+        // TODO: remove this after resetting testnet + integration of governance module
+        if unverified_block.message.execution_payload.block_number == 70132 {
+            Ok(())
+        }
+
         let (_execution_block, execution_receipts) =
             self.get_block_and_receipts(&prev_payload_hash).await?;
 

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -1130,7 +1130,7 @@ impl<DB: ItemStore<MainnetEthSpec>> Chain<DB> {
     ) -> Result<(), Error> {
         // TODO: remove this after resetting testnet + integration of governance module
         if unverified_block.message.execution_payload.block_number == 70132 {
-            Ok(())
+            return Ok(());
         }
 
         let (_execution_block, execution_receipts) =


### PR DESCRIPTION
This pull request introduces a temporary bypass for block verification in the `Chain` implementation to support ongoing testnet and governance module integration work. Specifically, it skips verification for a specific block number, which is intended to be removed after the testnet reset and governance module integration.

Temporary block verification bypass:

* In `app/src/chain.rs`, the `verify_block` method now skips verification for blocks with `execution_payload.block_number == 70132`, returning early to avoid processing this block. This is marked as a TODO and is intended for removal after testnet reset and governance module integration.